### PR TITLE
Fix bug when generateGoal is false

### DIFF
--- a/src/net/bytten/metazelda/generators/DungeonGenerator.java
+++ b/src/net/bytten/metazelda/generators/DungeonGenerator.java
@@ -416,7 +416,12 @@ public class DungeonGenerator implements IDungeonGenerator, ILogger {
      */
     protected List<Room> getSolutionPath() {
         List<Room> solution = new ArrayList<Room>();
-        Room room = dungeon.findGoal();
+        Room room;
+        if (isGenerateGoal()) {
+            room = dungeon.findGoal();
+        } else {
+            room = dungeon.findBoss();
+        }
         while (room != null) {
             solution.add(room);
             room = room.getParent();


### PR DESCRIPTION
If generateGoal is false, getSolutionPath would always return null, leading to placeSwitches always throwing an exception.
